### PR TITLE
Use latest Ruby versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.1.0
-  - 2.2.5
-  - 2.3.0
+  - 2.0.0-p648
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
 before_install: gem install bundler -v 1.13.7


### PR DESCRIPTION
Have Travis test against all `2.x` versions (latest patch).