### PR TITLE
Bump Version

### DIFF
--- a/lib/telephone_number/version.rb
+++ b/lib/telephone_number/version.rb
@@ -1,3 +1,3 @@
 module TelephoneNumber
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
We upgraded our base data to track Google's latest release(8.4.3), so
let's cut a new release

![bump](https://cloud.githubusercontent.com/assets/5104499/25199600/5e29ea20-2519-11e7-9373-ed7e4ad404f7.gif)
