### PR TITLE
CHORE: telephone_number refactor

### DIFF
--- a/lib/telephone_number.rb
+++ b/lib/telephone_number.rb
@@ -3,13 +3,13 @@ require 'utilities/hash'
 require 'forwardable'
 
 module TelephoneNumber
-  autoload :DataImporter, 'telephone_number/data_importer'
+  autoload :DataImporter,      'telephone_number/data_importer'
   autoload :TestDataGenerator, 'telephone_number/test_data_generator'
-  autoload :Parser, 'telephone_number/parser'
-  autoload :Number, 'telephone_number/number'
-  autoload :Formatter, 'telephone_number/formatter'
-  autoload :PhoneData, 'telephone_number/phone_data'
-  autoload :ClassMethods, 'telephone_number/class_methods'
+  autoload :Parser,            'telephone_number/parser'
+  autoload :Number,            'telephone_number/number'
+  autoload :Formatter,         'telephone_number/formatter'
+  autoload :PhoneData,         'telephone_number/phone_data'
+  autoload :ClassMethods,      'telephone_number/class_methods'
 
   extend ClassMethods
 
@@ -21,28 +21,4 @@ module TelephoneNumber
 
   # allows users to provide a default format string
   @default_format_string = nil
-
-  def self.override_file=(file_name)
-    @override_file = file_name
-  end
-
-  def self.override_file
-    @override_file
-  end
-
-  def self.default_format_string=(format_string)
-    @default_format_string = format_string
-  end
-
-  def self.default_format_string
-    @default_format_string
-  end
-
-  def self.default_format_pattern=(format_string)
-    @default_format_pattern = Regexp.new(format_string)
-  end
-
-  def self.default_format_pattern
-    @default_format_pattern
-  end
 end

--- a/lib/telephone_number/class_methods.rb
+++ b/lib/telephone_number/class_methods.rb
@@ -1,5 +1,12 @@
 module TelephoneNumber
   module ClassMethods
+    attr_accessor :override_file, :default_format_string
+    attr_reader :default_format_pattern
+
+    def default_format_pattern=(format_string)
+      @default_format_pattern = Regexp.new(format_string)
+    end
+
     def parse(number, country = Parser.detect_country(number))
       TelephoneNumber::Number.new(number, country)
     end

--- a/lib/telephone_number/data_importer.rb
+++ b/lib/telephone_number/data_importer.rb
@@ -94,4 +94,3 @@ module TelephoneNumber
     end
   end
 end
-

--- a/lib/telephone_number/formatter.rb
+++ b/lib/telephone_number/formatter.rb
@@ -109,5 +109,3 @@ module TelephoneNumber
     end
   end
 end
-
-

--- a/lib/telephone_number/parser.rb
+++ b/lib/telephone_number/parser.rb
@@ -50,11 +50,10 @@ module TelephoneNumber
     # basically anything else that uses google data
     def build_normalized_number
       return sanitized_number unless country_data
-      country_code = country_data[PhoneData::COUNTRY_CODE]
 
       number_with_correct_prefix = parse_prefix
 
-      reg_string = "^(#{country_code})?"
+      reg_string = "^(#{country_data[PhoneData::COUNTRY_CODE]})?"
       reg_string << "(#{country_data[PhoneData::NATIONAL_PREFIX]})?"
       reg_string << "(#{country_data[PhoneData::VALIDATIONS][PhoneData::GENERAL][PhoneData::VALID_PATTERN]})$"
 

--- a/lib/telephone_number/phone_data.rb
+++ b/lib/telephone_number/phone_data.rb
@@ -47,4 +47,3 @@ module TelephoneNumber
     end
   end
 end
-


### PR DESCRIPTION
Proposed refactoring for telephone_number

## Solution

Adds the attr_reader and writers out of `lib/telephone_number.rb` and into `lib/telephone_number/class_methods.rb`, removed extra newlines, and removed a variable initialization in favor of the original code since it was only used in the one spot and `PhoneData::COUNTRY_CODE` does a good job of representing what's at hand. 