### PR TITLE
Move country detection to Number class

### DIFF
--- a/lib/telephone_number/class_methods.rb
+++ b/lib/telephone_number/class_methods.rb
@@ -7,11 +7,11 @@ module TelephoneNumber
       @default_format_pattern = Regexp.new(format_string)
     end
 
-    def parse(number, country = detect_country(number))
+    def parse(number, country = nil)
       TelephoneNumber::Number.new(sanitize(number), country)
     end
 
-    def valid?(number, country = detect_country(number), keys = [])
+    def valid?(number, country = nil, keys = [])
       parse(number, country).valid?(keys)
     end
 
@@ -21,15 +21,6 @@ module TelephoneNumber
 
     def sanitize(input_number)
       input_number.to_s.gsub(/\D/, '')
-    end
-
-    def detect_country(number)
-      sanitized_number = sanitize(number)
-      detected_country = Country.all_countries.detect do |country|
-        sanitized_number.start_with?(country.country_code) && valid?(sanitized_number, country.country_id)
-      end
-
-      detected_country.country_id.to_sym if detected_country
     end
 
     # generates binary file from xml that user gives us

--- a/lib/telephone_number/number.rb
+++ b/lib/telephone_number/number.rb
@@ -7,11 +7,24 @@ module TelephoneNumber
     delegate [:valid?, :valid_types, :normalized_number] => :parser
     delegate [:national_number, :e164_number, :international_number] => :formatter
 
-    def initialize(number, country)
-      @original_number = number
-      @country = Country.find(country)
+    def initialize(number, country = nil)
+      @original_number = TelephoneNumber.sanitize(number)
+      @country = country ? Country.find(country) : detect_country
       @parser = Parser.new(self)
       @formatter = Formatter.new(self)
+    end
+
+    private
+
+    def detect_country
+      # note that it is entirely possible for two separate countries to use the same
+      # validation scheme. Take Italy and Vatican City for example.
+      eligible_countries = Country.all_countries.select do |country|
+        original_number.start_with?(country.country_code) && self.class.new(original_number, country.country_id).valid?
+      end
+
+      detected_country = eligible_countries.detect(&:main_country_for_code) || eligible_countries.first
+      Country.find(detected_country.country_id.to_sym) if detected_country
     end
   end
 end

--- a/test/telephone_number/number_test.rb
+++ b/test/telephone_number/number_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+module TelephoneNumber
+  class NumberTest < Minitest::Test
+
+    def setup
+      @valid_numbers = YAML.load_file('test/valid_numbers.yml')
+    end
+
+    def test_detects_country_if_nil
+      @valid_numbers.each do |country, number_object|
+        number_object.each do |_name, number_data|
+          detected_country = TelephoneNumber::Number.new(number_data[:e164_formatted], nil).country.country_id
+          assert_equal country.to_s, detected_country
+        end
+      end
+    end
+
+    def test_country_is_nil_with_invalid_input
+      detected_country = TelephoneNumber::Number.new('13175083384', 'NOTREAL').country
+      assert_nil detected_country
+    end
+  end
+end

--- a/test/telephone_number_test.rb
+++ b/test/telephone_number_test.rb
@@ -35,14 +35,6 @@ class TelephoneNumberTest < Minitest::Test
     assert_equal "123", TelephoneNumber.sanitize("abc123")
   end
 
-  def test_detect_country_for_numbers
-    @valid_numbers.each do |country, number_object|
-      number_object.each do |_name, number_data|
-        assert_equal country, TelephoneNumber.detect_country(number_data[:e164_formatted])
-      end
-    end
-  end
-
   def test_valid_formatted_national_number_for_countries
     @valid_numbers.each do |country, number_object|
       number_object.values.each do |number_data|
@@ -85,10 +77,6 @@ class TelephoneNumberTest < Minitest::Test
     assert_equal '+5581', number_obj.e164_number
   end
 
-  def test_detect_country_returns_nil_if_country_not_found
-    assert_nil TelephoneNumber.detect_country("1")
-  end
-
   def test_returns_empty_string_if_input_is_nil
     country_inputs = [nil, '', :us]
     number_inputs = [nil, '']
@@ -97,16 +85,6 @@ class TelephoneNumberTest < Minitest::Test
     country_inputs.product(number_inputs, methods).each do |country, number, method|
       assert_equal '', TelephoneNumber.parse(number, country).public_send(method)
     end
-  end
-
-  def test_valid_types_with_invalid_country_returns_false
-    assert_predicate TelephoneNumber.parse("448444156790", "NOTREAL").valid_types, :empty?
-  end
-
-  def test_returns_original_string_when_country_is_nil
-    assert_equal '13175082205', TelephoneNumber.parse('13175082205', nil).international_number
-    assert_equal '13175082205', TelephoneNumber.parse('13175082205', nil).national_number
-    assert_equal '13175082205', TelephoneNumber.parse('13175082205', nil).e164_number
   end
 
   def test_invalid_numbers_go_to_default_pattern


### PR DESCRIPTION
This commit moves the country detection functionality to the number
class in an effort to provide a stricter separation of concerns. It also
addresses specfic scenarios in the country detection process where two
countries share the same validation scheme.