### PR TITLE
Use relative file path for geolocation data file

### DIFF
--- a/lib/telephone_number/geo_locator.rb
+++ b/lib/telephone_number/geo_locator.rb
@@ -42,7 +42,7 @@ module TelephoneNumber
     end
 
     def geocoding_path(locale)
-      path = File.join('data', 'geocoding', locale.to_s, '*.dat')
+      path = File.expand_path("../../../data/geocoding/#{locale}/*.dat", __FILE__)
       Dir.glob(path)
     end
 

--- a/lib/telephone_number/version.rb
+++ b/lib/telephone_number/version.rb
@@ -1,3 +1,3 @@
 module TelephoneNumber
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end


### PR DESCRIPTION
This commit ensures that we're using the relative file path when pulling
geolocation data. Rookie mistake