### PR TITLE
National Prefix Formatting Rule cleanup

### DIFF
--- a/lib/telephone_number/country.rb
+++ b/lib/telephone_number/country.rb
@@ -1,26 +1,25 @@
 module TelephoneNumber
   class Country
-    attr_reader :country_code, :national_prefix, :national_prefix_formatting_rule,
-                :national_prefix_for_parsing, :national_prefix_transform_rule, :international_prefix,
-                :formats, :validations, :mobile_token, :country_id, :general_validation, :main_country_for_code
+    attr_reader :country_code, :national_prefix, :national_prefix_for_parsing,
+                :national_prefix_transform_rule, :international_prefix, :formats,
+                :validations, :mobile_token, :country_id, :general_validation, :main_country_for_code
 
     MOBILE_TOKEN_COUNTRIES = { AR: '9' }.freeze
 
     def initialize(data_hash)
       @country_code = data_hash[:country_code]
       @country_id = data_hash[:id]
-      @formats = data_hash.fetch(:formats, []).map { |format| NumberFormat.new(format) }
       @general_validation = NumberValidation.new(:general_desc, data_hash[:validations][:general_desc]) if data_hash.fetch(:validations, {})[:general_desc]
       @international_prefix = Regexp.new(data_hash[:international_prefix]) if data_hash[:international_prefix]
       @main_country_for_code = data_hash[:main_country_for_code] == 'true'
       @mobile_token = MOBILE_TOKEN_COUNTRIES[@country_id.to_sym]
       @national_prefix = data_hash[:national_prefix]
-      @national_prefix_formatting_rule = data_hash[:national_prefix_formatting_rule]
       @national_prefix_for_parsing = Regexp.new(data_hash[:national_prefix_for_parsing]) if data_hash[:national_prefix_for_parsing]
       @national_prefix_transform_rule = data_hash[:national_prefix_transform_rule]
       @validations = data_hash.fetch(:validations, {})
                               .except(:general_desc, :area_code_optional)
                               .map { |name, data| NumberValidation.new(name, data) }
+      @formats = data_hash.fetch(:formats, []).map { |format| NumberFormat.new(format, data_hash[:national_prefix_formatting_rule]) }
     end
 
     def detect_format(number)

--- a/lib/telephone_number/formatter.rb
+++ b/lib/telephone_number/formatter.rb
@@ -35,13 +35,12 @@ module TelephoneNumber
 
     def build_national_number(formatted: true)
       captures = normalized_number.match(number_format.pattern).captures
-      national_prefix_formatting_rule = number_format.national_prefix_formatting_rule || country.national_prefix_formatting_rule
 
       formatted_string = format(ruby_format_string(number_format.format), *captures)
       captures.delete(country.mobile_token)
 
-      if national_prefix_formatting_rule
-        national_prefix_string = national_prefix_formatting_rule.dup
+      if number_format.national_prefix_formatting_rule
+        national_prefix_string = number_format.national_prefix_formatting_rule.dup
         national_prefix_string.gsub!(/\$NP/, country.national_prefix)
         national_prefix_string.gsub!(/\$FG/, captures[0])
         formatted_string.sub!(captures[0], national_prefix_string)

--- a/lib/telephone_number/number.rb
+++ b/lib/telephone_number/number.rb
@@ -28,15 +28,16 @@ module TelephoneNumber
 
     private
 
-    def detect_country
+    def eligible_countries
       # note that it is entirely possible for two separate countries to use the same
       # validation scheme. Take Italy and Vatican City for example.
-      eligible_countries = Country.all_countries.select do |country|
+      Country.all_countries.select do |country|
         original_number.start_with?(country.country_code) && self.class.new(original_number, country.country_id).valid?
       end
+    end
 
-      detected_country = eligible_countries.detect(&:main_country_for_code) || eligible_countries.first
-      Country.find(detected_country.country_id.to_sym) if detected_country
+    def detect_country
+      eligible_countries.detect(&:main_country_for_code) || eligible_countries.first
     end
   end
 end

--- a/lib/telephone_number/number_format.rb
+++ b/lib/telephone_number/number_format.rb
@@ -3,12 +3,12 @@ module TelephoneNumber
 
     attr_reader :pattern, :leading_digits, :format, :national_prefix_formatting_rule, :intl_format
 
-    def initialize(data_hash)
+    def initialize(data_hash, country_prefix_formatting_rule)
       @pattern = Regexp.new(data_hash[:pattern]) if data_hash[:pattern]
       @leading_digits = Regexp.new(data_hash[:leading_digits]) if data_hash[:leading_digits]
       @format = data_hash[:format]
       @intl_format = data_hash[:intl_format]
-      @national_prefix_formatting_rule = data_hash[:national_prefix_formatting_rule]
+      @national_prefix_formatting_rule = data_hash[:national_prefix_formatting_rule] || country_prefix_formatting_rule
     end
   end
 end

--- a/test/telephone_number/country_test.rb
+++ b/test/telephone_number/country_test.rb
@@ -10,7 +10,6 @@ module TelephoneNumber
       assert_equal /011/, country.international_prefix
       assert_equal 2, country.formats.count
       assert_equal 5, country.validations.count
-      assert_nil country.national_prefix_formatting_rule
       assert_nil country.national_prefix_for_parsing
       assert_nil country.national_prefix_transform_rule
       assert_nil country.mobile_token


### PR DESCRIPTION
## context

We receive a `national_prefix_formatting_rule` attribute from Google that helps us determine how to format a number. We can receive this attribute in 1 of 2 ways. 

1. In the country data as a whole. This sets this attribute for all formats for the country. It's effectively a default value. 
2. Specified at the `NumberFormat` level. 

This commit removes this attribute from `Country` and instead just pushes this data down to `NumberFormat` so that it is ALWAYS set at the `NumberFormat` level. Doing this saves us an `if` check during processing. It also makes it a little more consistent. 