### PR TITLE
Validator: Configurable error message + more flexible country option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Or install it yourself as:
 
 #### Country
 
-- In this example, `record.country` must yield a valid two letter country code such as `:us` or `:ca`
+- In this example, `record.country` must yield a valid two letter country code such as `:us`, `:ca` or `'DE'`
+- You can also just pass a `String` or `Symbol` instead of a `Proc`.
 
 ## Manual Usage
 

--- a/lib/active_model/telephone_number_validator.rb
+++ b/lib/active_model/telephone_number_validator.rb
@@ -4,6 +4,10 @@ class TelephoneNumberValidator < ActiveModel::EachValidator
     valid_types = options.fetch(:types, [])
     args = [value, country, valid_types]
 
-    record.errors.add(attribute, :invalid) if TelephoneNumber.invalid?(*args)
+    record.errors.add(attribute, message) if TelephoneNumber.invalid?(*args)
+  end
+
+  def message
+    options[:message] || :invalid
   end
 end

--- a/lib/active_model/telephone_number_validator.rb
+++ b/lib/active_model/telephone_number_validator.rb
@@ -1,9 +1,14 @@
 class TelephoneNumberValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    country = options[:country].call(record) if options.key?(:country)
+    country_option = options[:country]
+    country = if country_option.is_a? Proc
+                country_option.call(record)
+              elsif country_option.is_a?(Symbol) || country_option.is_a?(String)
+                # make sure its a lowercase symbol
+                country_option.downcase.to_sym
+              end
     valid_types = options.fetch(:types, [])
     args = [value, country, valid_types]
-
     record.errors.add(attribute, message) if TelephoneNumber.invalid?(*args)
   end
 

--- a/lib/active_model/telephone_number_validator.rb
+++ b/lib/active_model/telephone_number_validator.rb
@@ -1,18 +1,21 @@
 class TelephoneNumberValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    country_option = options[:country]
-    country = if country_option.is_a? Proc
-                country_option.call(record)
-              elsif country_option.is_a?(Symbol) || country_option.is_a?(String)
-                # make sure its a lowercase symbol
-                country_option.downcase.to_sym
-              end
     valid_types = options.fetch(:types, [])
-    args = [value, country, valid_types]
+    args = [value, country(record), valid_types]
     record.errors.add(attribute, message) if TelephoneNumber.invalid?(*args)
   end
 
   def message
     options[:message] || :invalid
+  end
+
+  def country(record)
+    country_option = options[:country]
+    if country_option.is_a? Proc
+      country_option.call(record)
+    elsif country_option.is_a?(Symbol) || country_option.is_a?(String)
+      # make sure its a lowercase symbol
+      country_option.downcase.to_sym
+    end
   end
 end

--- a/lib/active_model/telephone_number_validator.rb
+++ b/lib/active_model/telephone_number_validator.rb
@@ -16,6 +16,8 @@ class TelephoneNumberValidator < ActiveModel::EachValidator
     elsif country_option.is_a?(Symbol) || country_option.is_a?(String)
       # make sure its a lowercase symbol
       country_option.downcase.to_sym
+    else
+      raise ArgumentError.new('country option must be a Proc, Symbol or String')
     end
   end
 end

--- a/test/active_model/model_test.rb
+++ b/test/active_model/model_test.rb
@@ -58,7 +58,7 @@ class ModelTest < Minitest::Test
 
   def test_with_invalid_option_for_country
     assert_raises ArgumentError do
-      CountryValidationWithArray.new('424324543645').valid?
+      CountryValidationWithArray.new(phone_number: '424324543645').valid?
     end
   end
 

--- a/test/active_model/model_test.rb
+++ b/test/active_model/model_test.rb
@@ -12,16 +12,18 @@ class ModelTest < Minitest::Test
     end
   end
 
+  ERR_MESSAGE = 'This is not a valid telephone number!'
+
   class BasicValidation < BasicModel
-    validates :phone_number, telephone_number: { country: proc{ |record| record.country } }
+    validates :phone_number, telephone_number: { country: proc{ |record| record.country }, message: ERR_MESSAGE }
   end
 
   class CountryValidationWithSymbol < BasicModel
-    validates :phone_number, telephone_number: { country: :us }
+    validates :phone_number, telephone_number: { country: :us, message: ERR_MESSAGE }
   end
 
   class CountryValidationWithString < BasicModel
-    validates :phone_number, telephone_number: { country: 'US' }
+    validates :phone_number, telephone_number: { country: 'US', message: ERR_MESSAGE }
   end
 
   class CountryValidationWithArray < BasicModel
@@ -31,7 +33,6 @@ class ModelTest < Minitest::Test
   class ValidationWithTypes < BasicModel
     validates :phone_number, telephone_number: { country: proc{ |record| record.country }, types: [:toll_free] }
   end
-
 
   class AllowBlankOption < BasicModel
     validates :phone_number, telephone_number: { country: proc{ |record| record.country } }, allow_blank: true
@@ -44,15 +45,16 @@ class ModelTest < Minitest::Test
     end
 
     basic_classes.each do |klass|
-      validation1 = klass.new(phone_number: '8')
-      assert validation1.invalid?
-      assert_includes validation1.errors, :phone_number
+      validation = klass.new(phone_number: '8')
+      assert validation.invalid?
+      assert_includes validation.errors, :phone_number
     end
 
     basic_classes.each do |klass|
-      validation2 = klass.new(phone_number: nil)
-      assert validation2.invalid?
-      assert_includes validation2.errors, :phone_number
+      validation = klass.new(phone_number: nil)
+      assert validation.invalid?
+      assert_includes validation.errors, :phone_number
+      assert_equal validation.errors[:phone_number].first, ERR_MESSAGE
     end
   end
 

--- a/test/active_model/model_test.rb
+++ b/test/active_model/model_test.rb
@@ -24,6 +24,10 @@ class ModelTest < Minitest::Test
     validates :phone_number, telephone_number: { country: 'US' }
   end
 
+  class CountryValidationWithArray < BasicModel
+    validates :phone_number, telephone_number: { country: [:us] }
+  end
+
   class ValidationWithTypes < BasicModel
     validates :phone_number, telephone_number: { country: proc{ |record| record.country }, types: [:toll_free] }
   end
@@ -49,6 +53,12 @@ class ModelTest < Minitest::Test
       validation2 = klass.new(phone_number: nil)
       assert validation2.invalid?
       assert_includes validation2.errors, :phone_number
+    end
+  end
+
+  def test_with_invalid_option_for_country
+    assert_raises ArgumentError do
+      CountryValidationWithArray.new('424324543645').valid?
     end
   end
 

--- a/test/active_model/model_test.rb
+++ b/test/active_model/model_test.rb
@@ -16,24 +16,40 @@ class ModelTest < Minitest::Test
     validates :phone_number, telephone_number: { country: proc{ |record| record.country } }
   end
 
+  class CountryValidationWithSymbol < BasicModel
+    validates :phone_number, telephone_number: { country: :us }
+  end
+
+  class CountryValidationWithString < BasicModel
+    validates :phone_number, telephone_number: { country: 'US' }
+  end
+
   class ValidationWithTypes < BasicModel
     validates :phone_number, telephone_number: { country: proc{ |record| record.country }, types: [:toll_free] }
   end
+
 
   class AllowBlankOption < BasicModel
     validates :phone_number, telephone_number: { country: proc{ |record| record.country } }, allow_blank: true
   end
 
   def test_basic_correctly_validates
-    assert BasicValidation.new(phone_number: "3175082489").valid?
+    basic_classes = [BasicValidation, CountryValidationWithSymbol, CountryValidationWithString]
+    basic_classes.each do |klass|
+      assert klass.new(phone_number: '3175082489').valid?
+    end
 
-    validation1 = BasicValidation.new(phone_number: "8")
-    assert validation1.invalid?
-    assert_includes validation1.errors, :phone_number
+    basic_classes.each do |klass|
+      validation1 = klass.new(phone_number: '8')
+      assert validation1.invalid?
+      assert_includes validation1.errors, :phone_number
+    end
 
-    validation2 = BasicValidation.new(phone_number: nil)
-    assert validation2.invalid?
-    assert_includes validation2.errors, :phone_number
+    basic_classes.each do |klass|
+      validation2 = klass.new(phone_number: nil)
+      assert validation2.invalid?
+      assert_includes validation2.errors, :phone_number
+    end
   end
 
   def test_with_types_correctly_validates


### PR DESCRIPTION
Hello,

I added the possibility to pass a message to the `telephone_number` validator like all the standard Rails validators have. While I was at it I made the `country` option of the validator accept Strings and Symbols, too.

Thanks for this lib!