### PR TITLE
BUGFIX: build national number

### DIFF
--- a/test/valid_numbers.yml
+++ b/test/valid_numbers.yml
@@ -1,6 +1,6 @@
-# This file is generated automatically by TestDataImporter. 
-# Any changes made to this file will be overridden next time test data is generated. 
-# Please edit TestDataImporter if you need to add test cases. 
+# This file is generated automatically by TestDataImporter.
+# Any changes made to this file will be overridden next time test data is generated.
+# Please edit TestDataImporter if you need to add test cases.
 ---
 :AE:
   '0':


### PR DESCRIPTION
When we went to update our metadata, one of our tests began to fail. In short, we were building the national number and international number in a way that differed with the way Google does it. 
This commit ensures that we're building national numbers the exact
same way as the libphonenumber library.