### PR TITLE
Accept a proc for the validator :message option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Or install it yourself as:
 ## Rails Validation
 
 `validates :my_attribute_name, telephone_number: {country: proc{|record| record.country}, types: [:fixed_line, :mobile, etc]}`
+`validates :my_attribute_name, telephone_number: {country: proc{|record| record.country}, types: [:fixed_line, :mobile, etc], message: proc{|record| "invalid for #{record.country} country"}}`
 
 #### Valid Phone Types
 - `:area_code_optional`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Or install it yourself as:
 ## Rails Validation
 
 `validates :my_attribute_name, telephone_number: {country: proc{|record| record.country}, types: [:fixed_line, :mobile, etc]}`
+
+#### Customize Message
+
 `validates :my_attribute_name, telephone_number: {country: proc{|record| record.country}, types: [:fixed_line, :mobile, etc], message: proc{|record| "invalid for #{record.country} country"}}`
 
 #### Valid Phone Types

--- a/lib/active_model/telephone_number_validator.rb
+++ b/lib/active_model/telephone_number_validator.rb
@@ -2,10 +2,10 @@ class TelephoneNumberValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     valid_types = options.fetch(:types, [])
     args = [value, country(record), valid_types]
-    record.errors.add(attribute, message) if TelephoneNumber.invalid?(*args)
+    record.errors.add(attribute, message(record)) if TelephoneNumber.invalid?(*args)
   end
 
-  def message
+  def message(record)
     message_option = options[:message]
     if message_option.is_a? Proc
       message_option.call(record)

--- a/lib/active_model/telephone_number_validator.rb
+++ b/lib/active_model/telephone_number_validator.rb
@@ -6,7 +6,12 @@ class TelephoneNumberValidator < ActiveModel::EachValidator
   end
 
   def message
-    options[:message] || :invalid
+    message_option = options[:message]
+    if message_option.is_a? Proc
+      message_option.call(record)
+    else
+      options[:message] || :invalid
+    end
   end
 
   def country(record)


### PR DESCRIPTION
Allow the `:message` option to accept a `proc` with a reference to the record, so you can customize the rails validation message a bit more.